### PR TITLE
Add matching brace highlights.

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetBraceMatcher.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetBraceMatcher.kt
@@ -1,0 +1,29 @@
+package com.github.zzehring.intellijjsonnet
+
+import com.github.zzehring.intellijjsonnet.psi.JsonnetTypes
+import com.intellij.lang.BracePair
+import com.intellij.lang.PairedBraceMatcher
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+
+class JsonnetBraceMatcher : PairedBraceMatcher {
+    override fun getPairs(): Array<BracePair> {
+        return PAIRS
+    }
+
+    override fun isPairedBracesAllowedBeforeType(type: IElementType, tokenType: IElementType?): Boolean {
+        return false
+    }
+
+    override fun getCodeConstructStart(file: PsiFile, openingBraceOffset: Int): Int {
+        return openingBraceOffset
+    }
+
+    companion object {
+        private val PAIRS = arrayOf(
+            BracePair(JsonnetTypes.L_BRACKET, JsonnetTypes.R_BRACKET, false),
+            BracePair(JsonnetTypes.L_PAREN, JsonnetTypes.R_PAREN, false),
+            BracePair(JsonnetTypes.L_CURLY, JsonnetTypes.R_CURLY, true)
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -58,6 +58,7 @@
                                        implementationClass="com.github.zzehring.intellijjsonnet.JsonnetSyntaxHighlighterFactory"/>
         <lang.foldingBuilder language="Jsonnet"
                              implementationClass="com.github.zzehring.intellijjsonnet.JsonnetFoldingBuilder"/>
+        <lang.braceMatcher language="Jsonnet" implementationClass="com.github.zzehring.intellijjsonnet.JsonnetBraceMatcher"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
This commit adds brace matching and highlighting for jsonnet. It
provides matching the following pairs:
 - "[" and "]"
 - "{" and "}"
 - "(" and ")"

This was taken from `databricks/intellij-jsonnet` project.

Fixes: #1