### PR TITLE
Bump pluginUntilBuild to 222.*

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 0.0.6
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 212
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
With the new releases of version 222 IDEs, we need to bump pluginUntilBuild accordingly.

Closes: #14