### PR TITLE
Remove `mentions_count` from `RepoRelease` to fix GitHub response.

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/releases/RepoRelease.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/releases/RepoRelease.kt
@@ -13,7 +13,6 @@ data class RepoRelease(
     val draft: Boolean,
     val html_url: String,
     val id: Int,
-    val mentions_count: Int,
     val name: String,
     val node_id: String,
     val prerelease: Boolean,


### PR DESCRIPTION
It seems as though GitHub is no longer returning `mentions_count` when listing releases via their REST API. This is resolved by removing that attribute from the `RepoRelease` dataclass.