### PR TITLE
Revert "Remove `mentions_count` from `RepoRelease` to fix GitHub response."

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/releases/RepoRelease.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/releases/RepoRelease.kt
@@ -13,6 +13,7 @@ data class RepoRelease(
     val draft: Boolean,
     val html_url: String,
     val id: Int,
+    val mentions_count: Int,
     val name: String,
     val node_id: String,
     val prerelease: Boolean,


### PR DESCRIPTION
Reverts zzehring/intellij-jsonnet#19

Looks like this field is now being returned from GitHub. Efforts should be made to make that GH request more resilient to failures.