### PR TITLE
chore: allow latest IDE versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [0.0.10]
+### Added
+- Allow compatibility with 223.* IDE versions
+
 ## [0.0.9]
 ### Added
 - Comment support

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = com.github.zzehring.intellijjsonnet
 pluginName = Jsonnet Language Server
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.9
+pluginVersion = 0.0.10
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 212
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2021.3.2
+platformVersion = 2021.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Fixes plugin not able to be enabled on latest IDE version(s)

Allow working with the latest IDEs

<img width="355" alt="image" src="https://user-images.githubusercontent.com/109269354/206965441-50cec4ab-acfd-491e-88c9-30a17aa73e76.png">
