### PR TITLE
bugfix: Add `ignoreUnknownKeys` to HttpClient's JsonBuilder

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetLSStartupHandler.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetLSStartupHandler.kt
@@ -61,6 +61,7 @@ class JsonnetLSStartupHandler {
                 json(Json {
                     prettyPrint = true
                     isLenient = true
+                    ignoreUnknownKeys = true
                 })
             }
         }


### PR DESCRIPTION
Getting latest release info from GitHub fails when they mess with the json returned from the endpoint (such as adding a new key/val).

Adding `ignoreUnknownKeys` to JsonBuilder should fix this issue.