### PR TITLE
Allow use of plugin with IntelliJ 2023.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Unreleased
 
+### Added
+- Allow compatibility with 232.* IDE versions
+
 ## 0.1.4 - 2023-07-05
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2023.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 0.1.4
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 222
-pluginUntilBuild = 231.*
+pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
Thanks for maintaining the plugin.

~~I'm adding these changes to make it work with the latest releases, but I haven't tested it locally if it works If someone can provide me some instructions, I'm happy to give it a try and validate.~~

I was able to verify and test it locally 👌 

For future reference, install the Gradle Plugin for your IDEA. Then run the `buildPlugin` Gradle task found under the `intellij` folder.
The zip file containing the plugin can be found in `{project_root}/build/distributions`.
You can install the plugin from disk and give it a try.