### PR TITLE
Allow use with IntelliJ 2023.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.7.21"
+    id("org.jetbrains.kotlin.jvm") version "1.9.21"
     // Gradle IntelliJ Plugin
     id("org.jetbrains.intellij") version "1.11.0"
     // Gradle Changelog Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ pluginVersion = 0.1.5
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 222
-pluginUntilBuild = 232.*
+pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2023.2
+platformVersion = 2023.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
I've based this on https://github.com/zzehring/intellij-jsonnet/pull/65 and the version table at https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions.