### PR TITLE
Add possibility to use custom jsonnet-language-server binary

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -13,10 +13,12 @@ import javax.swing.JPanel
 class JLSSettingsComponent {
     var myMainPanel: JPanel
     private val releaseRepository = JBTextField()
+    private val jsonnetLanguageServerCustomPath = JBTextField()
 
     init {
         this.myMainPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("Release Repo (Github Repository from which to download language server): "), releaseRepository, 1, true)
+            .addLabeledComponent(JBLabel("Custom path to language server binary: "), jsonnetLanguageServerCustomPath, 1, true)
             .addComponentFillVertically(JPanel(), 0)
             .panel
     }
@@ -29,9 +31,16 @@ class JLSSettingsComponent {
     fun getReleaseRepository(): String {
         return releaseRepository.text
     }
+    @NotNull
+    fun getJsonnetLanguageServerCustomPath(): String {
+        return jsonnetLanguageServerCustomPath.text
+    }
 
     fun setReleaseRepository(newPath: String) {
         releaseRepository.text = newPath
+    }
+    fun setJsonnetLanguageServerCustomPath(newPath: String) {
+        jsonnetLanguageServerCustomPath.text = newPath
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
@@ -18,11 +18,13 @@ class JLSSettingsConfigurable : Configurable {
     override fun isModified(): Boolean {
         val settings = JLSSettingsStateComponent.instance.state
         return mySettingsComponent.getReleaseRepository() != settings.releaseRepository
+                || mySettingsComponent.getJsonnetLanguageServerCustomPath() != settings.jsonnetLanguageServerCustomPath
     }
 
     override fun apply() {
         val settings = JLSSettingsStateComponent.instance.state
         settings.releaseRepository = mySettingsComponent.getReleaseRepository()
+        settings.jsonnetLanguageServerCustomPath = mySettingsComponent.getJsonnetLanguageServerCustomPath()
     }
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -37,6 +39,7 @@ class JLSSettingsConfigurable : Configurable {
     override fun reset() {
         val settings = JLSSettingsStateComponent.instance.state
         mySettingsComponent.setReleaseRepository(settings.releaseRepository)
+        mySettingsComponent.setJsonnetLanguageServerCustomPath(settings.jsonnetLanguageServerCustomPath)
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -30,5 +30,6 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
 
     class SettingsState {
         var releaseRepository = "grafana/jsonnet-language-server"
+        var jsonnetLanguageServerCustomPath = "path/to/binary/jsonnet-language-server"
     }
 }


### PR DESCRIPTION
This feature is particularly beneficial in scenarios where GitHub access is restricted or when there's a need to employ a specific, non-release version of the jsonnet-language-server.