### PR TITLE
feat(settings): allow enabling/disabling of language server diagnostics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.9.21"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.11.0"
+    id("org.jetbrains.intellij") version "1.17.2"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.0.0"
     // Kotlin Serializer Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@ pluginVersion = 0.1.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 222
-pluginUntilBuild = 233.*
+pluginSinceBuild = 233
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
@@ -23,7 +23,7 @@ platformPlugins =
 javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.3
+gradleVersion = 7.6
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetLSStartupHandler.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetLSStartupHandler.kt
@@ -49,6 +49,8 @@ class JsonnetLSStartupHandler {
     fun start() {
 
         val languageServerRepo = JLSSettingsStateComponent.instance.state.releaseRepository
+        val enableEvalDiagnostics = JLSSettingsStateComponent.instance.state.enableEvalDiagnostics
+        val enableLintDiagnostics = JLSSettingsStateComponent.instance.state.enableLintDiagnostics
         val platform = getPlatform()
         val arch = getArch()
 
@@ -95,10 +97,17 @@ class JsonnetLSStartupHandler {
         // Configure language server
         // TODO: Make --tanka configurable
         // TODO: add JPath configuration
+        var optionalArgs = arrayOf<String>()
+        if (enableEvalDiagnostics) {
+            optionalArgs += "--eval-diags"
+        }
+        if (enableLintDiagnostics) {
+            optionalArgs += "--lint"
+        }
         IntellijLanguageClient.addServerDefinition(
             RawCommandServerDefinition(
                 EXTENSIONS,
-                arrayOf(binFile.toString(), "--tanka", "--lint")
+                arrayOf(binFile.toString(), "--tanka", *optionalArgs)
             )
         )
     }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -1,5 +1,6 @@
 package com.github.zzehring.intellijjsonnet.settings
 
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
@@ -11,12 +12,18 @@ import javax.swing.JPanel
  * Supports creating and managing a {@link JPanel} for the Settings Dialog
  */
 class JLSSettingsComponent {
-    var myMainPanel: JPanel
+    var repoPanel: JPanel
     private val releaseRepository = JBTextField()
+    private val enableLintDiagnostics = JBCheckBox("Enable lint diagnostics on language server")
+    private val enableEvalDiagnostics = JBCheckBox("Enable eval diagnostics on language")
 
     init {
-        this.myMainPanel = FormBuilder.createFormBuilder()
+        this.repoPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("Release Repo (Github Repository from which to download language server): "), releaseRepository, 1, true)
+            .addComponent(enableEvalDiagnostics)
+            .addTooltip("Try to evaluate files to find errors and warnings. Disable on large projects to improve performance. IDE restart required.")
+            .addComponent(enableLintDiagnostics)
+            .addTooltip("Enable live linting diagnostics. Disable on large projects to improve performance. IDE restart required.")
             .addComponentFillVertically(JPanel(), 0)
             .panel
     }
@@ -32,6 +39,22 @@ class JLSSettingsComponent {
 
     fun setReleaseRepository(newPath: String) {
         releaseRepository.text = newPath
+    }
+
+    fun getEnableLintDiagnostics(): Boolean {
+        return enableLintDiagnostics.isSelected
+    }
+
+    fun setEnableLintDiagnostics(isSelected: Boolean) {
+        enableLintDiagnostics.isSelected = isSelected
+    }
+
+    fun getEnableEvalDiagnostics(): Boolean {
+        return enableEvalDiagnostics.isSelected
+    }
+
+    fun setEnableEvalDiagnostics(isSelected: Boolean) {
+        enableEvalDiagnostics.isSelected = isSelected
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
@@ -10,19 +10,25 @@ class JLSSettingsConfigurable : Configurable {
     private lateinit var mySettingsComponent: JLSSettingsComponent
 
     @Nullable
-    override fun createComponent(): JComponent? {
+    override fun createComponent(): JComponent {
         mySettingsComponent = JLSSettingsComponent()
-        return mySettingsComponent.myMainPanel
+        mySettingsComponent.setEnableLintDiagnostics(true)
+        mySettingsComponent.setEnableEvalDiagnostics(false)
+        return mySettingsComponent.repoPanel
     }
 
     override fun isModified(): Boolean {
         val settings = JLSSettingsStateComponent.instance.state
         return mySettingsComponent.getReleaseRepository() != settings.releaseRepository
+                || mySettingsComponent.getEnableEvalDiagnostics() != settings.enableEvalDiagnostics
+                || mySettingsComponent.getEnableLintDiagnostics() != settings.enableLintDiagnostics
     }
 
     override fun apply() {
         val settings = JLSSettingsStateComponent.instance.state
         settings.releaseRepository = mySettingsComponent.getReleaseRepository()
+        settings.enableEvalDiagnostics = mySettingsComponent.getEnableEvalDiagnostics()
+        settings.enableLintDiagnostics = mySettingsComponent.getEnableLintDiagnostics()
     }
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -37,6 +43,8 @@ class JLSSettingsConfigurable : Configurable {
     override fun reset() {
         val settings = JLSSettingsStateComponent.instance.state
         mySettingsComponent.setReleaseRepository(settings.releaseRepository)
+        mySettingsComponent.setEnableEvalDiagnostics(settings.enableEvalDiagnostics)
+        mySettingsComponent.setEnableLintDiagnostics(settings.enableLintDiagnostics)
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable
 
 @State(
     name = "com.github.zzehring.intellijjsonnet.JLSSettingsState",
-    storages = [Storage("SdkSettingsPlugin.xml")]
+    storages = [Storage("JsonnetLsSettingsPlugin.xml")]
 )
 open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsStateComponent.SettingsState> {
 
@@ -30,5 +30,7 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
 
     class SettingsState {
         var releaseRepository = "grafana/jsonnet-language-server"
+        var enableLintDiagnostics = false
+        var enableEvalDiagnostics = false
     }
 }


### PR DESCRIPTION
Surface plugin settings to allow setting lint and eval diagnostics. These settings are passed into the command for running the language server.

Disabling lint and eval diagnostics significantly improves performance for large projects.