### PR TITLE
feat: allow setting jpaths for language server

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -1,30 +1,50 @@
 package com.github.zzehring.intellijjsonnet.settings
 
+import com.intellij.ui.TableUtil
+import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
+import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.FormBuilder
 import org.jetbrains.annotations.NotNull
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.table.DefaultTableModel
 
 /**
  * Supports creating and managing a {@link JPanel} for the Settings Dialog
  */
 class JLSSettingsComponent {
-    var repoPanel: JPanel
+    var settingsPanel: JPanel
+    var jPathsPanel: JPanel
     private val releaseRepository = JBTextField()
     private val enableLintDiagnostics = JBCheckBox("Enable lint diagnostics on language server")
     private val enableEvalDiagnostics = JBCheckBox("Enable eval diagnostics on language")
+    private val jPathsTableModel = DefaultTableModel(arrayOf("JPath"), 0)
 
     init {
-        this.repoPanel = FormBuilder.createFormBuilder()
+        this.settingsPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("Release Repo (Github Repository from which to download language server): "), releaseRepository, 1, true)
             .addComponent(enableEvalDiagnostics)
             .addTooltip("Try to evaluate files to find errors and warnings. Disable on large projects to improve performance. IDE restart required.")
             .addComponent(enableLintDiagnostics)
             .addTooltip("Enable live linting diagnostics. Disable on large projects to improve performance. IDE restart required.")
-            .addComponentFillVertically(JPanel(), 0)
+            .panel
+        val jPathsTable = JBTable(jPathsTableModel)
+        val tablePanel = ToolbarDecorator.createDecorator(jPathsTable)
+            .setAddAction {
+                jPathsTableModel.addRow(arrayOf())
+                TableUtil.editCellAt(jPathsTable, jPathsTableModel.rowCount - 1, 0)
+            }
+            .setRemoveAction {
+                for (i in jPathsTable.selectedRows.reversed()) {
+                    jPathsTableModel.removeRow(i)
+                }
+            }
+            .createPanel()
+        jPathsPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("JPaths (Additional directories to search for jsonnet library files): "), tablePanel, 1, true)
             .panel
     }
 
@@ -55,6 +75,22 @@ class JLSSettingsComponent {
 
     fun setEnableEvalDiagnostics(isSelected: Boolean) {
         enableEvalDiagnostics.isSelected = isSelected
+    }
+
+    fun getJPaths(): List<String> {
+        val paths = mutableListOf<String>()
+        for (i in 0 until jPathsTableModel.rowCount) {
+            val aPath = jPathsTableModel.getValueAt(i, 0)
+            paths.add(aPath.toString())
+        }
+        return paths
+    }
+
+    fun setJPaths(paths: List<String>) {
+        jPathsTableModel.rowCount = 0
+        for (path in paths) {
+            jPathsTableModel.addRow(arrayOf(path))
+        }
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
@@ -3,7 +3,10 @@ package com.github.zzehring.intellijjsonnet.settings
 import com.intellij.openapi.options.Configurable
 import org.jetbrains.annotations.Nls
 import org.jetbrains.annotations.Nullable
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
 import javax.swing.JComponent
+import javax.swing.JPanel
 
 class JLSSettingsConfigurable : Configurable {
 
@@ -14,7 +17,18 @@ class JLSSettingsConfigurable : Configurable {
         mySettingsComponent = JLSSettingsComponent()
         mySettingsComponent.setEnableLintDiagnostics(true)
         mySettingsComponent.setEnableEvalDiagnostics(false)
-        return mySettingsComponent.repoPanel
+        val containerPanel = JPanel(GridBagLayout())
+        val constraints = GridBagConstraints()
+        constraints.fill = GridBagConstraints.HORIZONTAL
+        constraints.anchor = GridBagConstraints.NORTHWEST
+        constraints.weightx = 1.0
+        constraints.weighty = 1.0
+        constraints.gridx = 0
+        constraints.gridy = 0
+        containerPanel.add(mySettingsComponent.settingsPanel, constraints)
+        constraints.gridy = 1
+        containerPanel.add(mySettingsComponent.jPathsPanel, constraints)
+        return containerPanel
     }
 
     override fun isModified(): Boolean {
@@ -22,6 +36,7 @@ class JLSSettingsConfigurable : Configurable {
         return mySettingsComponent.getReleaseRepository() != settings.releaseRepository
                 || mySettingsComponent.getEnableEvalDiagnostics() != settings.enableEvalDiagnostics
                 || mySettingsComponent.getEnableLintDiagnostics() != settings.enableLintDiagnostics
+                || mySettingsComponent.getJPaths() != settings.jPaths
     }
 
     override fun apply() {
@@ -29,6 +44,7 @@ class JLSSettingsConfigurable : Configurable {
         settings.releaseRepository = mySettingsComponent.getReleaseRepository()
         settings.enableEvalDiagnostics = mySettingsComponent.getEnableEvalDiagnostics()
         settings.enableLintDiagnostics = mySettingsComponent.getEnableLintDiagnostics()
+        settings.jPaths = mySettingsComponent.getJPaths()
     }
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -45,6 +61,7 @@ class JLSSettingsConfigurable : Configurable {
         mySettingsComponent.setReleaseRepository(settings.releaseRepository)
         mySettingsComponent.setEnableEvalDiagnostics(settings.enableEvalDiagnostics)
         mySettingsComponent.setEnableLintDiagnostics(settings.enableLintDiagnostics)
+        mySettingsComponent.setJPaths(settings.jPaths)
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -32,5 +32,6 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
         var releaseRepository = "grafana/jsonnet-language-server"
         var enableLintDiagnostics = false
         var enableEvalDiagnostics = false
+        var jPaths = listOf<String>()
     }
 }


### PR DESCRIPTION
This exposes plugin configuration for configuring JPaths for the language server. Only valid, non-empty paths are passed.

Closes: #47