### PR TITLE
Fix incorrect plugin directory for language server binary

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetLSStartupHandler.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/JsonnetLSStartupHandler.kt
@@ -85,7 +85,7 @@ class JsonnetLSStartupHandler {
         val repoInfo = getLatestReleaseInfo(httpClient, releaseURL, platform, arch)
         log.info("Latest tag: ${repoInfo.tag} ; Download URL: ${repoInfo.downloadUrl}")
 
-        val binFile = File(PathManager.getPluginsPath().plus("/jsonnet-language-server/jsonnet-language-server"))
+        val binFile = File(PathManager.getPluginsPath().plus("/Jsonnet Language Server/jsonnet-language-server"))
 
         // Check if LS binary already exists. If it does and the latest release is a higher version, prompt user to update
         // If binary doesn't exist, download latest


### PR DESCRIPTION
This fixes errors like the following on startup after v0.3.0:

```
java.io.FileNotFoundException: /Users/charleskorn/Library/Application Support/JetBrains/IntelliJIdea2024.2/plugins/jsonnet-language-server/jsonnet-language-server (No such file or directory)
	at java.base/java.io.FileOutputStream.open0(Native Method)
	at java.base/java.io.FileOutputStream.open(FileOutputStream.java:289)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:230)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:179)
	at kotlin.io.FilesKt__FileReadWriteKt.writeBytes(FileReadWrite.kt:108)
	at com.github.zzehring.intellijjsonnet.JsonnetLSStartupHandler$download$1.invokeSuspend(JsonnetLSStartupHandler.kt:217)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:284)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.github.zzehring.intellijjsonnet.JsonnetLSStartupHandler.download(JsonnetLSStartupHandler.kt:213)
	at com.github.zzehring.intellijjsonnet.JsonnetLSStartupHandler.start(JsonnetLSStartupHandler.kt:95)
	at com.github.zzehring.intellijjsonnet.JsonnetLSBackgroundStartupActivity.runActivity(JsonnetLSBackgroundStartupActivity.kt:9)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchBackgroundPostStartupActivity$1$1.invoke(StartupManagerImpl.kt:470)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchBackgroundPostStartupActivity$1$1.invoke(StartupManagerImpl.kt:468)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContextInner(coroutines.kt:339)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invokeSuspend(coroutines.kt:232)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)
	at com.intellij.openapi.progress.CoroutinesKt$blockingContext$2.invoke(coroutines.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:62)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:261)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContext(coroutines.kt:231)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchBackgroundPostStartupActivity$1.invokeSuspend(StartupManagerImpl.kt:468)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:608)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:873)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:763)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:750)
```