### PR TITLE
fix: enable displaying server status widget in statusbar

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -63,6 +63,11 @@
         <lang.commenter
                 language="Jsonnet"
                 implementationClass="com.github.zzehring.intellijjsonnet.SimpleCommenter"/>
+
+        <!-- for displaying the statusbar icon -->
+        <statusBarWidgetFactory implementation="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                                id="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                                order="first" />
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
LS server status widget stopped displaying in the last release of the plugin. This change displays the server status widget once again.