### PR TITLE
chore: update plugin for IntelliJ 2024.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion = 0.3.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 233.2
-pluginUntilBuild = 242.*
+pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
IntelliJ 2024.3 has been released. This PR updates this plugin metadata to confirm it supports 2024.3.