### PR TITLE
chore: update plugin for IntelliJ 2025.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion = 0.3.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 233.2
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
IntelliJ 2025.1 has been released. This PR updates this plugin metadata to confirm it supports 2025.1.