### PR TITLE
[WIP] Allow configuring the lsp options

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -11,10 +11,88 @@ import org.jetbrains.annotations.NotNull
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.table.DefaultTableModel
+import javax.swing.JComboBox
+import javax.swing.JSeparator
+import java.awt.GridBagLayout
+import java.awt.GridBagConstraints
+import java.awt.GridLayout
+import javax.swing.BoxLayout
 
 /**
  * Supports creating and managing a {@link JPanel} for the Settings Dialog
  */
+class JLSFormattingOptionsComponent {
+    val panel: JPanel
+    private val quoteStyleComboBox = JComboBox(arrayOf("leave", "single", "double"))
+    private val commentStyleComboBox = JComboBox(arrayOf("leave", "hash", "slash"))
+    private val indentField = JBTextField("2", 3)
+    private val maxBlankLinesField = JBTextField("2", 3)
+    private val prettyFieldNamesCheckBox = JBCheckBox("Pretty Field Names", true)
+    private val useImplicitPlusCheckBox = JBCheckBox("Use Implicit Plus", true)
+    private val padArraysCheckBox = JBCheckBox("Pad Arrays", false)
+    private val padObjectsCheckBox = JBCheckBox("Pad Objects", true)
+    private val sortImportsCheckBox = JBCheckBox("Sort Imports", true)
+
+    init {
+        val leftPanel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("String Quote Style:"), quoteStyleComboBox)
+            .addLabeledComponent(JBLabel("Comment Style:"), commentStyleComboBox)
+            .addLabeledComponent(JBLabel("Indent:"), indentField)
+            .addLabeledComponent(JBLabel("Max Blank Lines:"), maxBlankLinesField)
+            .panel
+
+        val rightPanel = FormBuilder.createFormBuilder()
+            .addComponent(prettyFieldNamesCheckBox)
+            .addComponent(useImplicitPlusCheckBox)
+            .addComponent(padArraysCheckBox)
+            .addComponent(padObjectsCheckBox)
+            .addComponent(sortImportsCheckBox)
+            .panel
+
+        val contentPanel = JPanel()
+        contentPanel.layout = GridLayout(1, 2, 16, 0)
+        contentPanel.add(leftPanel)
+        contentPanel.add(rightPanel)
+
+        val headerPanel = FormBuilder.createFormBuilder()
+            .addComponent(JSeparator())
+            .addComponent(JBLabel("<html><b>Formatting Options</b></html>"))
+            .panel
+
+        panel = JPanel()
+        panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
+        panel.add(headerPanel)
+        panel.add(contentPanel)
+    }
+
+    fun getFormatting(): JLSSettingsStateComponent.FormattingConfiguration {
+        return JLSSettingsStateComponent.FormattingConfiguration(
+            quoteStyle = quoteStyleComboBox.selectedItem as String,
+            commentStyle = commentStyleComboBox.selectedItem as String,
+            indent = indentField.text.toIntOrNull() ?: 2,
+            maxBlankLines = maxBlankLinesField.text.toIntOrNull() ?: 2,
+            prettyFieldNames = prettyFieldNamesCheckBox.isSelected,
+            useImplicitPlus = useImplicitPlusCheckBox.isSelected,
+            padArrays = padArraysCheckBox.isSelected,
+            padObjects = padObjectsCheckBox.isSelected,
+            sortImports = sortImportsCheckBox.isSelected
+        )
+    }
+
+    fun setFormatting(formatting: JLSSettingsStateComponent.FormattingConfiguration) {
+        quoteStyleComboBox.selectedItem = formatting.quoteStyle
+        commentStyleComboBox.selectedItem = formatting.commentStyle
+        indentField.text = formatting.indent.toString()
+        maxBlankLinesField.text = formatting.maxBlankLines.toString()
+        prettyFieldNamesCheckBox.isSelected = formatting.prettyFieldNames
+        useImplicitPlusCheckBox.isSelected = formatting.useImplicitPlus
+        padArraysCheckBox.isSelected = formatting.padArrays
+        padObjectsCheckBox.isSelected = formatting.padObjects
+        sortImportsCheckBox.isSelected = formatting.sortImports
+    }
+
+}
+
 class JLSSettingsComponent {
     var settingsPanel: JPanel
     var jPathsPanel: JPanel
@@ -24,6 +102,7 @@ class JLSSettingsComponent {
     private val enableTankaMode = JBCheckBox("Enable Tanka mode")
     private val evalBinary = JBTextField()
     private val jPathsTableModel = DefaultTableModel(arrayOf("JPath"), 0)
+    private val formattingComponent = JLSFormattingOptionsComponent()
 
     init {
         this.settingsPanel = FormBuilder.createFormBuilder()
@@ -45,6 +124,7 @@ class JLSSettingsComponent {
                 "When set, file and expression evaluation use this command instead of the built-in VM." +
                 "</body></html>"
             )
+            .addComponent(formattingComponent.panel)
             .panel
         val jPathsTable = JBTable(jPathsTableModel)
         val tablePanel = ToolbarDecorator.createDecorator(jPathsTable)
@@ -120,4 +200,11 @@ class JLSSettingsComponent {
         }
     }
 
+    fun getFormatting(): JLSSettingsStateComponent.FormattingConfiguration {
+        return formattingComponent.getFormatting()
+    }
+
+    fun setFormatting(formatting: JLSSettingsStateComponent.FormattingConfiguration) {
+        formattingComponent.setFormatting(formatting)
+    }
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
@@ -19,6 +19,7 @@ class JLSSettingsConfigurable : Configurable {
         mySettingsComponent = JLSSettingsComponent()
         mySettingsComponent.setEnableLintDiagnostics(true)
         mySettingsComponent.setEnableEvalDiagnostics(false)
+
         val containerPanel = JPanel(GridBagLayout())
         val constraints = GridBagConstraints()
         constraints.fill = GridBagConstraints.HORIZONTAL
@@ -41,6 +42,7 @@ class JLSSettingsConfigurable : Configurable {
                 || mySettingsComponent.getEnableTankaMode() != settings.enableTankaMode
                 || mySettingsComponent.getEvalBinary() != settings.evalBinary
                 || mySettingsComponent.getJPaths() != settings.jPaths
+                || mySettingsComponent.getFormatting() != settings.formatting
     }
 
     override fun apply() {
@@ -62,6 +64,7 @@ class JLSSettingsConfigurable : Configurable {
                 wrapper.requestManager?.didChangeConfiguration(params)
             }
         }
+        settings.formatting = mySettingsComponent.getFormatting()
     }
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -81,6 +84,7 @@ class JLSSettingsConfigurable : Configurable {
         mySettingsComponent.setEnableTankaMode(settings.enableTankaMode)
         mySettingsComponent.setEvalBinary(settings.evalBinary)
         mySettingsComponent.setJPaths(settings.jPaths)
+        mySettingsComponent.setFormatting(settings.formatting)
     }
 
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -28,6 +28,18 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
         settingsState = state
     }
 
+    data class FormattingConfiguration(
+        var quoteStyle: String = "leave",
+        var commentStyle: String = "leave",
+        var indent: Int = 2,
+        var maxBlankLines: Int = 2,
+        var prettyFieldNames: Boolean = true,
+        var useImplicitPlus: Boolean = true,
+        var padArrays: Boolean = false,
+        var padObjects: Boolean = true,
+        var sortImports: Boolean = true
+    )
+
     class SettingsState {
         var releaseRepository = "grafana/jsonnet-language-server"
         var enableLintDiagnostics = false
@@ -35,5 +47,6 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
         var jPaths = listOf<String>()
         var enableTankaMode = true
         var evalBinary = ""
+        var formatting = FormattingConfiguration()
     }
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/utils/MyEditorEventManager.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/utils/MyEditorEventManager.kt
@@ -4,7 +4,9 @@ import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.github.zzehring.intellijjsonnet.settings.JLSSettingsStateComponent
 import org.apache.commons.lang3.StringUtils
+import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.FormattingOptions
 import org.eclipse.lsp4j.TextDocumentIdentifier
@@ -27,6 +29,23 @@ class MyEditorEventManager(
      */
     fun reformat() {
         ApplicationUtils.pool {
+            // Send the user's configured quote style to the LSP server
+            val formatting = JLSSettingsStateComponent.instance.state.formatting
+            val conf = mapOf(
+                "formatting" to mapOf(
+                    "StringStyle" to formatting.quoteStyle,
+                    "CommentStyle" to formatting.commentStyle,
+                    "Indent" to formatting.indent,
+                    "MaxBlankLines" to formatting.maxBlankLines,
+                    "PrettyFieldNames" to formatting.prettyFieldNames,
+                    "UseImplicitPlus" to formatting.useImplicitPlus,
+                    "PadArrays" to formatting.padArrays,
+                    "PadObjects" to formatting.padObjects,
+                    "SortImports" to formatting.sortImports
+                )
+            )
+            requestManager.didChangeConfiguration(DidChangeConfigurationParams(conf))
+
             if (editor.isDisposed) {
                 return@pool
             }
@@ -91,7 +110,7 @@ class MyEditorEventManager(
             var cur = 0
             while (cur < lspEdits.size - 1) {
                 val left = cur
-                while (lspEdits[cur].startOffset == lspEdits[cur+1].startOffset) {
+                while (lspEdits[cur].startOffset == lspEdits[cur + 1].startOffset) {
                     cur++
                 }
                 if (left < cur) {


### PR DESCRIPTION
This is a work-in-progress, but looking for some feedback if this is the right direction.

This adds all the styles from go-jsonnet to the settings and sends it to the lsp server when reformating a file

Note, this assumes the selected lsp server is `grafana/jsonnet-language-server` or compatible. I don't know if there's a way to detect what options are supported, but it's probably not worth the effort.