### PR TITLE
feat: add eval_binary setting to configure external evaluation command

### DIFF
--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -22,6 +22,7 @@ class JLSSettingsComponent {
     private val enableLintDiagnostics = JBCheckBox("Enable lint diagnostics on language server")
     private val enableEvalDiagnostics = JBCheckBox("Enable eval diagnostics on language")
     private val enableTankaMode = JBCheckBox("Enable Tanka mode")
+    private val evalBinary = JBTextField()
     private val jPathsTableModel = DefaultTableModel(arrayOf("JPath"), 0)
 
     init {
@@ -33,6 +34,17 @@ class JLSSettingsComponent {
             .addTooltip("Enable live linting diagnostics. Disable on large projects to improve performance. IDE restart required.")
             .addComponent(enableTankaMode)
             .addTooltip("Resolve import paths using Tanka conventions and enable Tanka native functions. Disable if not using Tanka. IDE restart required.")
+            .addVerticalGap(10)
+            .addLabeledComponent(
+                JBLabel("Eval Binary: "),
+                evalBinary, 1, true
+            )
+            .addTooltip(
+                "<html><body style='width: 500px'>" +
+                "External command for evaluation (e.g. \"jsonnet\" or \"tk\"). " +
+                "When set, file and expression evaluation use this command instead of the built-in VM." +
+                "</body></html>"
+            )
             .panel
         val jPathsTable = JBTable(jPathsTableModel)
         val tablePanel = ToolbarDecorator.createDecorator(jPathsTable)
@@ -87,6 +99,10 @@ class JLSSettingsComponent {
     fun setEnableTankaMode(isSelected: Boolean) {
         enableTankaMode.isSelected = isSelected
     }
+
+    fun getEvalBinary(): String = evalBinary.text
+
+    fun setEvalBinary(value: String) { evalBinary.text = value }
 
     fun getJPaths(): List<String> {
         val paths = mutableListOf<String>()

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -23,7 +23,6 @@ class JLSSettingsComponent {
     private val enableEvalDiagnostics = JBCheckBox("Enable eval diagnostics on language")
     private val enableTankaMode = JBCheckBox("Enable Tanka mode")
     private val evalBinary = JBTextField()
-    private val enableTankaMode = JBCheckBox("Enable Tanka mode")
     private val jPathsTableModel = DefaultTableModel(arrayOf("JPath"), 0)
 
     init {

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsComponent.kt
@@ -23,6 +23,7 @@ class JLSSettingsComponent {
     private val enableEvalDiagnostics = JBCheckBox("Enable eval diagnostics on language")
     private val enableTankaMode = JBCheckBox("Enable Tanka mode")
     private val evalBinary = JBTextField()
+    private val enableTankaMode = JBCheckBox("Enable Tanka mode")
     private val jPathsTableModel = DefaultTableModel(arrayOf("JPath"), 0)
 
     init {

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
@@ -1,8 +1,10 @@
 package com.github.zzehring.intellijjsonnet.settings
 
 import com.intellij.openapi.options.Configurable
+import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.jetbrains.annotations.Nls
 import org.jetbrains.annotations.Nullable
+import org.wso2.lsp4intellij.IntellijLanguageClient
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import javax.swing.JComponent
@@ -37,6 +39,7 @@ class JLSSettingsConfigurable : Configurable {
                 || mySettingsComponent.getEnableEvalDiagnostics() != settings.enableEvalDiagnostics
                 || mySettingsComponent.getEnableLintDiagnostics() != settings.enableLintDiagnostics
                 || mySettingsComponent.getEnableTankaMode() != settings.enableTankaMode
+                || mySettingsComponent.getEvalBinary() != settings.evalBinary
                 || mySettingsComponent.getJPaths() != settings.jPaths
     }
 
@@ -46,7 +49,19 @@ class JLSSettingsConfigurable : Configurable {
         settings.enableEvalDiagnostics = mySettingsComponent.getEnableEvalDiagnostics()
         settings.enableLintDiagnostics = mySettingsComponent.getEnableLintDiagnostics()
         settings.enableTankaMode = mySettingsComponent.getEnableTankaMode()
+        settings.evalBinary = mySettingsComponent.getEvalBinary()
         settings.jPaths = mySettingsComponent.getJPaths()
+
+        // Send eval_binary to the running language server without requiring restart
+        val evalBinary = settings.evalBinary
+        IntellijLanguageClient.getProjectToLanguageWrappers().forEach { (_, wrappers) ->
+            wrappers.forEach { wrapper ->
+                val params = DidChangeConfigurationParams(
+                    mapOf("eval_binary" to evalBinary)
+                )
+                wrapper.requestManager.didChangeConfiguration(params)
+            }
+        }
     }
 
     @Nls(capitalization = Nls.Capitalization.Title)
@@ -64,6 +79,7 @@ class JLSSettingsConfigurable : Configurable {
         mySettingsComponent.setEnableEvalDiagnostics(settings.enableEvalDiagnostics)
         mySettingsComponent.setEnableLintDiagnostics(settings.enableLintDiagnostics)
         mySettingsComponent.setEnableTankaMode(settings.enableTankaMode)
+        mySettingsComponent.setEvalBinary(settings.evalBinary)
         mySettingsComponent.setJPaths(settings.jPaths)
     }
 

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JLSSettingsConfigurable.kt
@@ -59,7 +59,7 @@ class JLSSettingsConfigurable : Configurable {
                 val params = DidChangeConfigurationParams(
                     mapOf("eval_binary" to evalBinary)
                 )
-                wrapper.requestManager.didChangeConfiguration(params)
+                wrapper.requestManager?.didChangeConfiguration(params)
             }
         }
     }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -35,5 +35,6 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
         var jPaths = listOf<String>()
         var enableTankaMode = true
         var evalBinary = ""
+        var enableTankaMode = true
     }
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -34,5 +34,6 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
         var enableEvalDiagnostics = false
         var jPaths = listOf<String>()
         var enableTankaMode = true
+        var evalBinary = ""
     }
 }

--- a/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
+++ b/src/main/kotlin/com/github/zzehring/intellijjsonnet/settings/JSLSettingsStateComponent.kt
@@ -35,6 +35,5 @@ open class JLSSettingsStateComponent : PersistentStateComponent<JLSSettingsState
         var jPaths = listOf<String>()
         var enableTankaMode = true
         var evalBinary = ""
-        var enableTankaMode = true
     }
 }


### PR DESCRIPTION
PR description:

This is a feature that was added very recentrly in vscode plugin. But I do not use vscode https://github.com/grafana/vscode-jsonnet/commit/0b6a4240b3279f38d79a5ee04401865fd9a0500d

  ---
  Summary

  - Add evalBinary setting that lets users specify an external command (e.g. jsonnet, jrsonnet, tk) for evaluation instead of the language server's built-in VM
  - Setting is sent to the running language server via LSP DidChangeConfiguration on Apply, no IDE restart required
  - New text field in Settings > Tools > Jsonnet Language Server with an HTML-wrapped tooltip

  Changes

  - JSLSettingsStateComponent.kt — Add evalBinary field to persisted SettingsState
  - JLSSettingsComponent.kt — Add JBTextField with label and tooltip to the settings form
  - JLSSettingsConfigurable.kt — Wire evalBinary into isModified/apply/reset; send DidChangeConfiguration to running servers on apply

  Test plan

  - ./gradlew build passes
  - Open Settings > Tools > Jsonnet Language Server — "Eval Binary" field appears with tooltip
  - Enter a value, click Apply, close/reopen settings — value persists
  - Change value — Apply button becomes enabled
  - Set to jsonnet, evaluate a .jsonnet file — server uses external binary


https://github.com/user-attachments/assets/d776df0b-7d28-4808-b5ce-672154d78e2b

Made with @claude